### PR TITLE
progress indicatorを1撃で全画面表示するようにした

### DIFF
--- a/lib/screens/copy_writing.dart
+++ b/lib/screens/copy_writing.dart
@@ -24,6 +24,8 @@ class _CopyWritingState extends State<CopyWriting> {
 
   bool visibleBool = false;
 
+  bool sendButtonActive = true;
+
   String prompt =
       "あなたは世界で最も優秀な広告マーケターです。添付の画像に対する商品の広告文を提案してください。回答は200文字以内でタイトルと広告文を返してください。なお、タイトルは太字にしてください。";
 
@@ -61,6 +63,12 @@ class _CopyWritingState extends State<CopyWriting> {
     String imageToSend = base64Encode(imageToRender!.toList());
 
     setState(() {
+      sendButtonActive = false;
+    });
+
+    await Future.delayed(const Duration(milliseconds: 450));
+
+    setState(() {
       visibleBool = true;
     });
 
@@ -73,6 +81,7 @@ class _CopyWritingState extends State<CopyWriting> {
       showErrorDialog(context, "リクエストに失敗しました");
     } finally {
       setState(() {
+        sendButtonActive = true;
         visibleBool = false;
       });
     }
@@ -115,7 +124,11 @@ class _CopyWritingState extends State<CopyWriting> {
                                       child: const Icon(Icons.folder),
                                     ),
                                     MaterialButton(
-                                      onPressed: _handleGenerate,
+                                      onPressed: (sendButtonActive)
+                                          ? () async {
+                                              _handleGenerate();
+                                            }
+                                          : null,
                                       child: const Icon(Icons.send),
                                     ),
                                   ],

--- a/lib/screens/edit_image.dart
+++ b/lib/screens/edit_image.dart
@@ -25,6 +25,8 @@ class _EditImageState extends State<EditImage> {
 
   bool visibleBool = false;
 
+  bool sendButtonActive = true;
+
   @override
   void initState() {
     super.initState();
@@ -55,6 +57,12 @@ class _EditImageState extends State<EditImage> {
 
   Future<void> handleGenerate(context, String prompt) async {
     setState(() {
+      sendButtonActive = false;
+    });
+
+    await Future.delayed(const Duration(milliseconds: 450));
+
+    setState(() {
       visibleBool = true;
     });
 
@@ -66,6 +74,7 @@ class _EditImageState extends State<EditImage> {
       showErrorDialog(context, "リクエストに失敗しました");
     } finally {
       setState(() {
+        sendButtonActive = true;
         visibleBool = false;
       });
     }
@@ -106,14 +115,17 @@ class _EditImageState extends State<EditImage> {
                                   maxLines: 2,
                                   decoration: InputDecoration(
                                     suffixIcon: IconButton(
-                                      onPressed: () async {
-                                        final prompt =
-                                            _textController.value.text;
-                                        if (prompt != "" &&
-                                            pickedImage != null) {
-                                          await handleGenerate(context, prompt);
-                                        }
-                                      },
+                                      onPressed: (sendButtonActive)
+                                          ? () async {
+                                              final prompt =
+                                                  _textController.value.text;
+                                              if (prompt != "" &&
+                                                  pickedImage != null) {
+                                                await handleGenerate(
+                                                    context, prompt);
+                                              }
+                                            }
+                                          : null,
                                       icon: const Icon(Icons.send),
                                     ),
                                   ),
@@ -154,4 +166,3 @@ class _EditImageState extends State<EditImage> {
     );
   }
 }
-

--- a/lib/screens/generate_image.dart
+++ b/lib/screens/generate_image.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:google_next_imagen_demo/utils/error_dialog.dart';
 import 'package:google_next_imagen_demo/utils/loading_indicator.dart';
 import 'package:google_next_imagen_demo/utils/render_image_widget.dart';
@@ -23,6 +22,8 @@ class _GenerateImageState extends State<GenerateImage> {
 
   bool visibleBool = false;
 
+  bool sendButtonActive = true;
+
   @override
   void initState() {
     super.initState();
@@ -37,6 +38,12 @@ class _GenerateImageState extends State<GenerateImage> {
 
   Future<void> handleGenerate(context, prompt) async {
     setState(() {
+      sendButtonActive = false;
+    });
+
+    await Future.delayed(const Duration(milliseconds: 450));
+
+    setState(() {
       visibleBool = true;
     });
 
@@ -47,6 +54,7 @@ class _GenerateImageState extends State<GenerateImage> {
       showErrorDialog(context, "リクエストに失敗しました");
     } finally {
       setState(() {
+        sendButtonActive = true;
         visibleBool = false;
       });
     }
@@ -84,12 +92,16 @@ class _GenerateImageState extends State<GenerateImage> {
                                   maxLines: 2,
                                   decoration: InputDecoration(
                                     suffixIcon: IconButton(
-                                      onPressed: () async {
-                                        final prompt = _controller.value.text;
-                                        if (prompt != "") {
-                                          await handleGenerate(context, prompt);
-                                        }
-                                      },
+                                      onPressed: (sendButtonActive)
+                                          ? () async {
+                                              final prompt =
+                                                  _controller.value.text;
+                                              if (prompt != "") {
+                                                await handleGenerate(
+                                                    context, prompt);
+                                              }
+                                            }
+                                          : null,
                                       icon: const Icon(Icons.send),
                                     ),
                                   ),
@@ -114,4 +126,3 @@ class _GenerateImageState extends State<GenerateImage> {
     );
   }
 }
-


### PR DESCRIPTION
・原因は文字入力時にキーボードが出てきた際に画面の描画領域が狭くなり、キーボードが閉じ終わるまで描画領域が狭くなってしまいprogress indicatorも狭い描画が先行してしまうこと。
・flutter webではキーボードの存在検知ができなかったため、苦肉の策としてスリープを導入
・スリープの間、送信ボタンを複数か押せないよう非活性化した