### PR TITLE
imagen3 fastの利用

### DIFF
--- a/lib/utils/vertexai.dart
+++ b/lib/utils/vertexai.dart
@@ -42,7 +42,7 @@ class VertexAI {
       final res = await http.post(
         Uri.https(
           'us-central1-aiplatform.googleapis.com',
-          'v1/projects/next-tokyo-imagen-flutter-demo/locations/us-central1/publishers/google/models/imagen-3.0-generate-preview-0611:predict',
+          'v1/projects/next-tokyo-imagen-flutter-demo/locations/us-central1/publishers/google/models/imagen-3.0-fast-generate-preview-0611:predict',
         ),
         headers: headers,
         body: jsonEncode(body),
@@ -143,9 +143,7 @@ class VertexAI {
           }
         ]
       },
-      "safety_settings": {
-        "threshold":"BLOCK_LOW_AND_ABOVE"
-      }
+      "safety_settings": {"threshold": "BLOCK_LOW_AND_ABOVE"}
     };
 
     debugPrint('...calling Gemini 1.5 Flash to get the copy');
@@ -211,9 +209,7 @@ class VertexAI {
           }
         ]
       },
-      "safety_settings": {
-        "threshold":"BLOCK_LOW_AND_ABOVE"
-      }
+      "safety_settings": {"threshold": "BLOCK_LOW_AND_ABOVE"}
     };
 
     debugPrint('...calling Gemini 1.5 Flash to enhance the prompt');


### PR DESCRIPTION
-画質比較
https://docs.google.com/spreadsheets/d/1PquEN-6iwqYYTf7nmz3YtETwT-dwjZ2xTFNPcCFDuE8/edit?gid=0#gid=0

-速度比較
Imagen3 :15s
Imagen3-Fast : 6-8s

-実機[Imagen3]
https://next-tokyo-imagen-flutter-demo.web.app/

-実機[Imagen3-fast]
https://stg-next-tokyo-imagen-flutter.web.app/